### PR TITLE
Implement form field matching directive.

### DIFF
--- a/tests/components/idp/register.html
+++ b/tests/components/idp/register.html
@@ -1,23 +1,67 @@
 <h1 align="center">Register</h1>
 
 <div ng-controller="RegisterController as model">
-  <form class="form-horizontal" role="form">
+  <form name="regForm" class="form-horizontal" role="form" novalidate
+    ng-submit="registrationForm()">
     <fieldset>
-      <br-input br-model="model.username"
-        br-options="{name: 'email', label: 'Email'}">
-        Please enter your email address.
-      </br-input>
-      <br-input br-model="model.passphrase"
-         br-options="{name: 'passphrase', label: 'Passphrase', type: 'password'}">
-        Please enter a passphrase.
-      </br-input>
-      <br-input br-model="model.passphraseConfirmation"
-         br-options="{name: 'passphraseConfirmation', label: 'Confirm Passphrase', type: 'password'}">
-        Please confirm your passphrase.
-      </br-input>
+      <div class="row">
+        <br-input br-model="model.username"
+          br-options="{name: 'email', label: 'Email'}"
+          ng-minlength=6 ng-maxlength=128 required>
+          Please enter your email address.
+        </br-input>
+        <div class="error" ng-show="regForm.email.$invalid && regForm.submitted">
+          <small class="error"
+            ng-show="regForm.email.$error.required">
+            Email is required.
+          </small>
+          <small class="error"
+            ng-show="regForm.email.$error.minlength">
+            Email is required to be at least 6 characters.
+          </small>
+          <small class="error"
+            ng-show="regForm.email.$error.maxlength">
+            Email must not be longer than 128 characters.
+          </small>
+        </div>
+      </div>
+      <div class="row">
+        <br-input br-model="model.passphrase"
+           br-options="{name: 'passphrase', label: 'Passphrase', type: 'password'}"
+           ng-minlength=6 ng-maxlength=128 required>
+          Please enter a passphrase.
+        </br-input>
+        <div class="error" ng-show="regForm.passphrase.$invalid && regForm.submitted">
+          <small class="error"
+            ng-show="regForm.passphrase.$error.required">
+            Passphrase is required.
+          </small>
+          <small class="error"
+            ng-show="regForm.passphrase.$error.minlength">
+            Passphrase is required to be at least 6 characters.
+          </small>
+          <small class="error"
+            ng-show="regForm.passphrase.$error.maxlength">
+            Passphrase must not be longer than 128 characters.
+          </small>
+        </div>
+      </div>
+      <div class="row">
+        <br-input br-model="model.passphraseConfirmation"
+           br-options="{name: 'passphraseConfirmation', label: 'Confirm Passphrase', type: 'password'}"
+           passphrase-check="model.passphrase" ng-model="model.passphraseConfirmation">
+          Please confirm your passphrase.
+        </br-input>
+        <div class="error" ng-show="regForm.$error.passphraseMatch && regForm.submitted">
+          <small class="error"
+            ng-show="regForm.$error.passphraseMatch">
+            Passphrase and Confirm Passphrase must match.
+          </small>
+        </div>
+      </div>
       <div style="text-align:center;">
         <button ng-disabled="model.registering || model.generating"
-          ng-click="model.register()" type="submit"
+          ng-click="model.registrationForm()" type="submit"
           class="btn btn-primary">Submit</button>
       </div>
       <div style="text-align:center;" ng-show="model.generating">
@@ -26,4 +70,10 @@
       </div>
     </fieldset>
   </form>
+  <div>
+    Form Valid: {{ regForm.$valid }}<br/>
+    Passphrase Error: {{ regForm.passphrase.$error }}<br/>
+    Confirm Error: {{ regForm.passphraseConfirmation.$error }}<br/>
+    Form Error: {{ regForm.$error }}<br/>
+  </div>
 </div>

--- a/tests/components/idp/register.html
+++ b/tests/components/idp/register.html
@@ -7,10 +7,10 @@
       <div class="row">
         <br-input br-model="model.username"
           br-options="{name: 'email', label: 'Email'}"
-          ng-minlength=6 ng-maxlength=128 required>
+          ng-minlength="6" ng-maxlength="128" required>
           Please enter your email address.
         </br-input>
-        <div class="error" ng-show="regForm.email.$invalid && regForm.submitted">
+        <div class="error" ng-show="regForm.email.$invalid && regForm.submitAttempted">
           <small class="error"
             ng-show="regForm.email.$error.required">
             Email is required.
@@ -28,10 +28,10 @@
       <div class="row">
         <br-input br-model="model.passphrase"
            br-options="{name: 'passphrase', label: 'Passphrase', type: 'password'}"
-           ng-minlength=6 ng-maxlength=128 required>
+           ng-minlength="6" ng-maxlength="128" required>
           Please enter a passphrase.
         </br-input>
-        <div class="error" ng-show="regForm.passphrase.$invalid && regForm.submitted">
+        <div class="error" ng-show="regForm.passphrase.$invalid && regForm.submitAttempted">
           <small class="error"
             ng-show="regForm.passphrase.$error.required">
             Passphrase is required.
@@ -48,20 +48,23 @@
       </div>
       <div class="row">
         <br-input br-model="model.passphraseConfirmation"
-           br-options="{name: 'passphraseConfirmation', label: 'Confirm Passphrase', type: 'password'}"
-           passphrase-check="model.passphrase" ng-model="model.passphraseConfirmation">
+         br-options="{name: 'passphraseConfirmation',
+         label: 'Confirm Passphrase', type: 'password'}"
+         br-input-aio-matches-input="model.passphrase">
           Please confirm your passphrase.
         </br-input>
-        <div class="error" ng-show="regForm.$error.passphraseMatch && regForm.submitted">
+        <div class="error"
+          ng-show="regForm.passphraseConfirmation.$error.inputMatch &&
+          regForm.submitAttempted">
           <small class="error"
-            ng-show="regForm.$error.passphraseMatch">
+            ng-show="regForm.passphraseConfirmation.$error.inputMatch">
             Passphrase and Confirm Passphrase must match.
           </small>
         </div>
       </div>
       <div style="text-align:center;">
         <button ng-disabled="model.registering || model.generating"
-          ng-click="model.registrationForm()" type="submit"
+          ng-click="model.validateForm()" type="submit"
           class="btn btn-primary">Submit</button>
       </div>
       <div style="text-align:center;" ng-show="model.generating">
@@ -70,10 +73,4 @@
       </div>
     </fieldset>
   </form>
-  <div>
-    Form Valid: {{ regForm.$valid }}<br/>
-    Passphrase Error: {{ regForm.passphrase.$error }}<br/>
-    Confirm Error: {{ regForm.passphraseConfirmation.$error }}<br/>
-    Form Error: {{ regForm.$error }}<br/>
-  </div>
 </div>

--- a/tests/components/idp/register.js
+++ b/tests/components/idp/register.js
@@ -7,11 +7,25 @@ define([
 
 'use strict';
 
-var module = angular.module('app.register', ['bedrock.alert']);
+var module = angular.module('app.register', ['bedrock.alert', 'app.register.directives']);
 var didio = didiojs({inject: {
   forge: forge,
   uuid: uuid
 }});
+
+angular.module('app.register.directives', [])
+  .directive('passphraseCheck', [function() {
+    return {
+      require: 'ngModel',
+      link: function(scope, elem, attrs, ctrl) {
+        var me = attrs.ngModel;
+        var matchTo = attrs.passphraseCheck;
+        scope.$watchGroup([me, matchTo], function(value){
+          ctrl.$setValidity('passphraseMatch', value[0] === value[1] );
+        });
+      }
+    }
+  }]);
 
 module.controller('RegisterController', function(
   $scope, $http, $window, config, DataService, brAlertService) {
@@ -22,6 +36,15 @@ module.controller('RegisterController', function(
   }
   if(config.data.registrationCallback) {
     DataService.set('callback', config.data.registrationCallback);
+  }
+
+  self.submitted = false;
+  self.registrationForm = function() {
+    if ($scope.regForm.$valid) {
+      self.register();
+    } else {
+      $scope.regForm.submitted = true;
+    }
   }
 
   self.passphraseConfirmation = '';
@@ -35,6 +58,7 @@ module.controller('RegisterController', function(
   }
 
   self.register = function() {
+    /*
     // TODO: Add more validation checks
     if(self.passphrase != self.passphraseConfirmation) {
       return brAlertService.add('error',
@@ -44,6 +68,7 @@ module.controller('RegisterController', function(
       return brAlertService.add('error',
         'You failed to provide an email address');
     }
+    */
     var idp = DataService.get('idp');
 
     // generate the private key

--- a/tests/components/idp/register.js
+++ b/tests/components/idp/register.js
@@ -7,29 +7,34 @@ define([
 
 'use strict';
 
-var module = angular.module('app.register', ['bedrock.alert', 'app.register.directives']);
+var module = angular.module('app.register', ['bedrock.alert']);
 var didio = didiojs({inject: {
   forge: forge,
   uuid: uuid
 }});
 
-angular.module('app.register.directives', [])
-  .directive('passphraseCheck', [function() {
-    return {
-      require: 'ngModel',
-      link: function(scope, elem, attrs, ctrl) {
-        var me = attrs.ngModel;
-        var matchTo = attrs.passphraseCheck;
-        scope.$watchGroup([me, matchTo], function(value){
-          ctrl.$setValidity('passphraseMatch', value[0] === value[1] );
-        });
-      }
+module.directive('aioMatchesInput', [function() {
+  return {
+    require: 'ngModel',
+    link: function(scope, elem, attrs, ctrl) {
+      var me = attrs.ngModel;
+      var matchTo = attrs.aioMatchesInput;
+      scope.$watchGroup([me, matchTo], function(value){
+        ctrl.$setValidity('inputMatch', value[0] === value[1] );
+      });
     }
-  }]);
+  }
+}]);
 
 module.controller('RegisterController', function(
   $scope, $http, $window, config, DataService, brAlertService) {
   var self = this;
+  self.submitAttempted = false;
+  self.passphraseConfirmation = '';
+  self.passphrase = '';
+  self.username = '';
+  self.registering = false;
+  self.generating = false;
 
   if(config.data.idp) {
     DataService.set('idp', config.data.idp);
@@ -38,20 +43,13 @@ module.controller('RegisterController', function(
     DataService.set('callback', config.data.registrationCallback);
   }
 
-  self.submitted = false;
-  self.registrationForm = function() {
+  self.validateForm = function() {
     if ($scope.regForm.$valid) {
       self.register();
     } else {
-      $scope.regForm.submitted = true;
+      $scope.regForm.submitAttempted = true;
     }
   }
-
-  self.passphraseConfirmation = '';
-  self.passphrase = '';
-  self.username = '';
-  self.registering = false;
-  self.generating = false;
 
   if(!DataService.get('idp')) {
     DataService.redirect('/register/idp-error');


### PR DESCRIPTION
I believe I have struck upon an issue related to the changes you made the other day related to using the angular validation directives.  Here's a codepen of some code I modeled mine after: http://codepen.io/anon/pen/ZGLWXQ?editors=101

note on the codepen that the $error object on the input field contains the 'validationErrorKey' which in this case is 'pwMatch'

for some reason, the validationErrorKey is being placed on the form object, not the input.

I should be able to reference the error with : regForm.passphraseConfirmation$error.passphraseMatch
but instead, I must access it using regForm.$error.passphraseMatch

the other oddity is that in order to get this working, I had to declare the ng-model on the input field here: https://github.com/mattcollier/authorization.io/blob/matchdirective/tests/components/idp/register.html#L52

I believe this is redundant, as I believe br-model also establishes the ng-model, but I was not able to get it working without explicitly specifying the ng-model.

If you pull up the registration form using my code, you will see some relevant variables displayed at the bottom of the page.