### PR TITLE
Prevent proof from being submitted early.

### DIFF
--- a/components/identity/identity-service.js
+++ b/components/identity/identity-service.js
@@ -741,9 +741,14 @@ function factory($http) {
             });
           }
           var waitTime = secondsLeft * 1000;
-          setTimeout(function() {
-            return resolve(proof);
-          }, waitTime);
+          // additional 250ms added to account for clock issues
+          var notBefore = Date.now() + waitTime + 250;
+          var i = setInterval(function() {
+            if(Date.now() >= notBefore) {
+              clearInterval(i);
+              return resolve(proof);
+            }
+          }, 500);
         });
     });
   }


### PR DESCRIPTION
@dlongley I spent the weekend developing at protractor test suite for bedrock-idp that allows us to hammer on the join process, including the DID registration in authio.  I started noticing a failure in about 15% of cases where the DID registration would fail.

I eventually discovered that the failure was caused by the front end submitting the proof of patience token too soon.  The typical discrepancy that I observed prior to the patch was ~200ms.

This is a very perplexing problem, and I was very surprised that implementing `setInterval` alone did not solve the problem.  With `setInterval` alone, I saw one case where the discrepancy was 61ms.

Here is a gist that contains the root cause of the issue and a link to the code that throws the error: https://gist.github.com/mattcollier/3daf31a0ca942b20daf36c5c40455dd0