### PR TITLE
Fix footer hr with updated dependencies.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,9 +5,10 @@
   "description": "authorization.io website bower dependencies.",
   "dependencies": {
     "angular-cookie": "~4.0.6",
-    "bedrock-angular": "^2.5.1",
+    "bedrock-angular": "^2.6.0",
     "bedrock-angular-alert": "^2.0.0",
     "bedrock-angular-credential": "^2.0.0",
+    "bedrock-angular-footer": "^3.1.0",
     "bedrock-angular-form": "^2.10.0",
     "bedrock-angular-filters": "^2.0.0",
     "bedrock-angular-identity-composer": "^1.0.0",


### PR DESCRIPTION
Updating and adding these dependencies will fix the issue of an hr
appearing when the site is used in an iframe.  The footer is disabled on
the site but the module is still needed to add the flag to not show the
hr.