### PR TITLE
Keep 1p dialog panel filling the popup height.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # authn.io ChangeLog
 
+## 7.3.1 - 2026-06-dd
+
+### Fixed
+- Keep the 1p dialog content panel filling the popup height so the page
+  background no longer shows through below short content (visible as a
+  black band in dark mode).
+
 ## 7.3.0 - 2026-06-12
 
 ### Changed

--- a/web/app.less
+++ b/web/app.less
@@ -51,9 +51,15 @@
 
   /* let the content panel grow with its children (the modal scrolls
      instead), so the panel background fully wraps tall content like the
-     cross-device QR section */
+     cross-device QR section; keep `min-height` so the panel still fills
+     the popup when content is short (otherwise the page background shows
+     through below it, e.g. as a black band in dark mode) */
   .wrm-modal-content {
+    /* include padding in `min-height: 100%` (the panel defaults to
+       content-box, which would overflow the popup by its padding) */
+    box-sizing: border-box;
     height: auto;
+    min-height: 100%;
     max-height: none;
   }
 }


### PR DESCRIPTION
Follow-up to #167. The scrolling fix there replaced the 1p dialog content panel's `height: 100%` with `height: auto`, so when content is shorter than the popup (e.g. no cross-device QR section), the page background shows through below the panel — visible as a black band in dark mode.

Adds `min-height: 100%` (with `box-sizing: border-box` so the panel's padding doesn't overflow the popup) so the panel always fills the popup while still growing with tall content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)