### PR TITLE
Keep 1p dialog panel filling the popup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,13 @@
 ## 7.3.1 - 2026-06-12
 
 ### Fixed
-- Keep the 1p dialog content panel filling the popup, so the page
-  background no longer shows through below short content or on either
-  side of the panel (visible as black bands in dark mode).
+- Keep the 1p dialog header fixed and scroll only the body region
+  between the header and footer, so the Close button never scrolls
+  away and the popup window no longer adds a second scrollbar on top
+  of the wallet list's own.
+- Keep the 1p dialog content panel exactly filling the popup, so the
+  page background no longer shows through below or beside the panel
+  (visible as black bands in dark mode).
 
 ## 7.3.0 - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # authn.io ChangeLog
 
-## 7.3.1 - 2026-06-12
+## 7.4.0 - 2026-06-dd
 
 ### Changed
 - Put the cross-device QR code behind an expander in the wallet
@@ -25,6 +25,13 @@
   `::-webkit-scrollbar*` rules when standard scrollbar properties are
   also set) so the list reliably shows a persistent scrollbar as the
   affordance that more wallets are available.
+
+## 7.3.1 - 2026-06-12
+
+### Fixed
+- Keep the 1p dialog content panel filling the popup height so the page
+  background no longer shows through below short content (visible as a
+  black band in dark mode).
 
 ## 7.3.0 - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 7.3.1 - 2026-06-12
 
+### Changed
+- Put the cross-device QR code behind an expander in the wallet
+  chooser. The always-visible prompt ("Don't see your wallet? Is your
+  wallet on another device?") keeps the option discoverable while
+  leaving the dialog compact — and giving the wallet list more room —
+  until the user asks for the code.
+
 ### Fixed
 - Lay the 1p dialog out as a fixed frame around the wallet hint list:
   the header, greeting, and cross-device QR section always stay on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
   chooser. The always-visible prompt ("Don't see your wallet?") keeps
   the option discoverable while leaving the dialog compact — and
   giving the wallet list more room — until the user asks for the
-  code.
+  code. When no wallets are registered, the QR code is the primary
+  option and shows immediately, with no expander.
 
 ### Fixed
 - Lay the 1p dialog out as a fixed frame around the wallet hint list:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,20 @@
 ## 7.3.1 - 2026-06-12
 
 ### Fixed
-- Keep the 1p dialog header fixed and scroll only the body region
-  between the header and footer, so the Close button never scrolls
-  away and the popup window no longer adds a second scrollbar on top
-  of the wallet list's own.
+- Lay the 1p dialog out as a fixed frame around the wallet hint list:
+  the header, greeting, and cross-device QR section always stay on
+  screen and only the wallet list scrolls. The Close button can no
+  longer scroll away, the popup window never adds a second scrollbar,
+  and the QR section stays visible as an affordance at any popup
+  height.
 - Keep the 1p dialog content panel exactly filling the popup, so the
   page background no longer shows through below or beside the panel
   (visible as black bands in dark mode).
+- Fix the wallet hint list's custom scrollbar styling (an invalid
+  `scrollbar-width` value, and Chromium 121+ ignoring
+  `::-webkit-scrollbar*` rules when standard scrollbar properties are
+  also set) so the list reliably shows a persistent scrollbar as the
+  affordance that more wallets are available.
 
 ## 7.3.0 - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## 7.3.1 - 2026-06-12
 
 ### Fixed
-- Keep the 1p dialog content panel filling the popup height so the page
-  background no longer shows through below short content (visible as a
-  black band in dark mode).
+- Keep the 1p dialog content panel filling the popup, so the page
+  background no longer shows through below short content or on either
+  side of the panel (visible as black bands in dark mode).
 
 ## 7.3.0 - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ### Changed
 - Put the cross-device QR code behind an expander in the wallet
-  chooser. The always-visible prompt ("Don't see your wallet? Is your
-  wallet on another device?") keeps the option discoverable while
-  leaving the dialog compact — and giving the wallet list more room —
-  until the user asks for the code.
+  chooser. The always-visible prompt ("Don't see your wallet?") keeps
+  the option discoverable while leaving the dialog compact — and
+  giving the wallet list more room — until the user asks for the
+  code.
 
 ### Fixed
 - Lay the 1p dialog out as a fixed frame around the wallet hint list:

--- a/web/app.less
+++ b/web/app.less
@@ -19,9 +19,12 @@
 /* Make hint list scrollable with custom thin scrollbar */
 .wrm-hint-list {
   max-height: 200px;
-  scrollbar-width: 6px;
-  scrollbar-color: @wrm-gray @wrm-dark-gray;
 
+  /* Chromium/WebKit: a persistent custom scrollbar. Do not also set the
+     standard `scrollbar-width`/`scrollbar-color` properties here —
+     Chromium 121+ ignores all `::-webkit-scrollbar*` styling when either
+     standard property is set, which silently reverts the scrollbar to
+     the platform default (invisible-at-rest overlay on macOS) */
   &::-webkit-scrollbar {
     width: 6px;
   }
@@ -33,6 +36,12 @@
     border-radius: 6px;
     box-shadow: inset 0 0 6px @wrm-gray;
   }
+
+  /* Firefox (no `::-webkit-scrollbar` support): nearest equivalent */
+  @supports not selector(::-webkit-scrollbar) {
+    scrollbar-width: thin;
+    scrollbar-color: @wrm-gray @wrm-dark-gray;
+  }
 }
 
 /* Adjust padding and margin for hint list items to accommodate scrollbar */
@@ -43,18 +52,18 @@
   margin-right: 1px;
 }
 
-/* Keep the 1p dialog header (and footer) fixed and scroll only the body
-   region between them, so content below the fold (e.g. the cross-device
-   QR section) stays reachable without scrolling the whole popup window
-   (which would scroll the header/Close button away and stack a window
-   scrollbar on top of the hint list's own) */
+/* Lay the 1p dialog out as a fixed frame around one scrollable region:
+   the header, greeting, and cross-device QR section always stay on
+   screen, and only the wallet hint list scrolls. This avoids scrolling
+   the popup window (which scrolled the header/Close button away and
+   stacked a second scrollbar on top of the hint list's own) and keeps
+   the QR section visible as an affordance at any popup height */
 .wrm-modal.wrm-modal-1p {
   /* make the content panel exactly fill the popup — never grow with
-     content (the body region scrolls instead) and never come up short
-     (the page background would show through as black bands in dark
-     mode); `border-box` + `width/height: 100%` includes the panel
-     padding, replacing upstream's content-box `calc(100% - padding)`
-     sizing */
+     content and never come up short (the page background would show
+     through as black bands in dark mode); `border-box` +
+     `width/height: 100%` includes the panel padding, replacing
+     upstream's content-box `calc(100% - padding)` sizing */
   .wrm-modal-content {
     box-sizing: border-box;
     height: 100%;
@@ -71,12 +80,61 @@
     }
 
     /* the body slot wrapper (the header's sibling) absorbs the
-       remaining height and scrolls its own overflow; `min-height: 0`
-       lets it shrink below its content size inside the flex column */
+       remaining height as a flex column; `overflow-y: auto` is only a
+       fallback for windows too short to fit even the fixed parts */
     > .wrm-modal-content-header + div {
+      display: flex;
       flex: 1 1 auto;
+      flex-direction: column;
       min-height: 0;
       overflow-y: auto;
+
+      /* fixed (non-scrolling) parts: greeting, separator, etc. */
+      > * {
+        flex-shrink: 0;
+      }
+
+      /* the hint chooser absorbs the remaining height */
+      > .hint-chooser {
+        display: flex;
+        flex: 1 1 auto;
+        flex-direction: column;
+        min-height: 0;
+
+        > .wrm-slide {
+          display: flex;
+          flex: 1 1 auto;
+          flex-direction: column;
+          min-height: 0;
+
+          /* fixed parts: message, QR section, web-share button */
+          > * {
+            flex-shrink: 0;
+          }
+
+          /* the wallet list region is the only shrinkable part, down
+             to ~one wallet row (below that, the body fallback scroll
+             takes over); the list itself scrolls — never a wrapper
+             around it, which would nest two scrollbars */
+          > .wrm-flex-column-stretch {
+            flex-shrink: 1;
+            min-height: 62px;
+
+            &:not(.wrm-hint-list) {
+              overflow-y: hidden;
+            }
+          }
+
+          .wrm-hint-list {
+            flex: 1 1 auto;
+            /* always show at least ~one wallet row */
+            min-height: 62px;
+            /* grow with available space instead of the fixed 200px
+               cap used in the 3p dialog */
+            max-height: none;
+          }
+        }
+      }
     }
   }
 }

--- a/web/app.less
+++ b/web/app.less
@@ -70,6 +70,12 @@
   &:focus-visible {
     text-decoration: underline;
   }
+
+  /* match the dialog's dark-mode body text (the default gray sinks
+     into the dark panel background) */
+  @media (prefers-color-scheme: dark) {
+    color: #d9d9d9;
+  }
 }
 
 /* Lay the 1p dialog out as a fixed frame around one scrollable region:

--- a/web/app.less
+++ b/web/app.less
@@ -43,31 +43,40 @@
   margin-right: 1px;
 }
 
-/* Allow vertical scrolling in the 1p dialog so content below the fold
-   (e.g. the cross-device QR section) stays reachable when the popup is
-   shorter than its content */
+/* Keep the 1p dialog header (and footer) fixed and scroll only the body
+   region between them, so content below the fold (e.g. the cross-device
+   QR section) stays reachable without scrolling the whole popup window
+   (which would scroll the header/Close button away and stack a window
+   scrollbar on top of the hint list's own) */
 .wrm-modal.wrm-modal-1p {
-  overflow-y: auto;
-
-  /* let the content panel grow with its children (the modal scrolls
-     instead), so the panel background fully wraps tall content like the
-     cross-device QR section; keep `min-height` so the panel still fills
-     the popup when content is short (otherwise the page background shows
-     through below it, e.g. as a black band in dark mode) */
+  /* make the content panel exactly fill the popup — never grow with
+     content (the body region scrolls instead) and never come up short
+     (the page background would show through as black bands in dark
+     mode); `border-box` + `width/height: 100%` includes the panel
+     padding, replacing upstream's content-box `calc(100% - padding)`
+     sizing */
   .wrm-modal-content {
-    /* include padding in `min-height: 100%` (the panel defaults to
-       content-box, which would overflow the popup by its padding) */
     box-sizing: border-box;
-    height: auto;
-    min-height: 100%;
+    height: 100%;
     max-height: none;
-    /* upstream sets `width: calc(100% - padding)` assuming content-box;
-       with border-box that calc becomes the total width and leaves gaps
-       on either side, so use the full width (padding now included) */
     width: 100%;
 
     &.wrm-modern {
       width: 100%;
+    }
+
+    /* the header never scrolls or shrinks */
+    > .wrm-modal-content-header {
+      flex-shrink: 0;
+    }
+
+    /* the body slot wrapper (the header's sibling) absorbs the
+       remaining height and scrolls its own overflow; `min-height: 0`
+       lets it shrink below its content size inside the flex column */
+    > .wrm-modal-content-header + div {
+      flex: 1 1 auto;
+      min-height: 0;
+      overflow-y: auto;
     }
   }
 }

--- a/web/app.less
+++ b/web/app.less
@@ -52,6 +52,26 @@
   margin-right: 1px;
 }
 
+/* Expander row for the cross-device QR section: always on screen (the
+   prompt text is the affordance that a cross-device option exists), with
+   the QR code itself revealed on demand */
+.cross-device-toggle {
+  color: @wrm-dark-gray;
+  cursor: pointer;
+  padding: 1em 0 0.5em;
+  text-align: center;
+
+  > .fas {
+    font-size: 12px;
+    margin-left: 6px;
+  }
+
+  &:hover,
+  &:focus-visible {
+    text-decoration: underline;
+  }
+}
+
 /* Lay the 1p dialog out as a fixed frame around one scrollable region:
    the header, greeting, and cross-device QR section always stay on
    screen, and only the wallet hint list scrolls. This avoids scrolling

--- a/web/app.less
+++ b/web/app.less
@@ -61,5 +61,13 @@
     height: auto;
     min-height: 100%;
     max-height: none;
+    /* upstream sets `width: calc(100% - padding)` assuming content-box;
+       with border-box that calc becomes the total width and leaves gaps
+       on either side, so use the full width (padding now included) */
+    width: 100%;
+
+    &.wrm-modern {
+      width: 100%;
+    }
   }
 }

--- a/web/components/CrossDeviceOptions.vue
+++ b/web/components/CrossDeviceOptions.vue
@@ -12,7 +12,7 @@
       @click="toggle()"
       @keydown.enter.prevent="toggle()"
       @keydown.space.prevent="toggle()">
-      <span>Don't see your wallet? Is your wallet on another device?</span>
+      <span>Don't see your wallet?</span>
       <i
         class="fas"
         :class="expanded ? 'fa-chevron-up' : 'fa-chevron-down'" />
@@ -21,7 +21,7 @@
       v-if="expanded"
       style="text-align: center">
       <div class="wrm-dark-gray">
-        Scan this code with the other device:
+        Scan this code on a device with your wallet:
       </div>
       <img
         v-if="qrDataUrl"

--- a/web/components/CrossDeviceOptions.vue
+++ b/web/components/CrossDeviceOptions.vue
@@ -20,8 +20,11 @@
         class="fas"
         :class="expanded ? 'fa-chevron-up' : 'fa-chevron-down'" />
     </div>
+    <!-- without the toggle row above it, the block provides its own
+      spacing below the separator -->
     <div
       v-if="expanded"
+      :style="{paddingTop: collapsible ? '0' : '1em'}"
       style="text-align: center">
       <div class="wrm-dark-gray">
         Scan this code on a device with your wallet:

--- a/web/components/CrossDeviceOptions.vue
+++ b/web/components/CrossDeviceOptions.vue
@@ -3,8 +3,11 @@
     <div
       class="wrm-separator wrm-modern"
       style="margin: 15px -15px 0px" />
-    <!-- expander: the QR code is hidden until the user asks for it -->
+    <!-- expander: the QR code is hidden until the user asks for it
+      (unless not collapsible, e.g. when there are no wallets and the
+      QR code is the primary option) -->
     <div
+      v-if="collapsible"
       class="cross-device-toggle"
       role="button"
       tabindex="0"
@@ -55,12 +58,17 @@
  * Copyright (c) 2026, Digital Bazaar, Inc.
  * All rights reserved.
  */
-import {ref, watchEffect} from 'vue';
+import {ref, toRef, watch, watchEffect} from 'vue';
 import QRCode from 'qrcode';
 
 export default {
   name: 'CrossDeviceOptions',
   props: {
+    collapsible: {
+      type: Boolean,
+      required: false,
+      default: true
+    },
     interactionUrl: {
       type: String,
       required: true
@@ -73,8 +81,17 @@ export default {
   },
   emits: ['close'],
   setup(props, {emit}) {
-    const expanded = ref(false);
+    // start expanded when not collapsible (the QR code is the
+    // primary option, e.g. no wallets are available)
+    const expanded = ref(!props.collapsible);
     const toggle = () => expanded.value = !expanded.value;
+    // auto-expand if the QR code becomes the primary option (e.g. the
+    // user hides the last wallet in the list)
+    watch(toRef(props, 'collapsible'), collapsible => {
+      if(!collapsible) {
+        expanded.value = true;
+      }
+    });
 
     const qrDataUrl = ref('');
     watchEffect(async () => {

--- a/web/components/CrossDeviceOptions.vue
+++ b/web/components/CrossDeviceOptions.vue
@@ -3,9 +3,25 @@
     <div
       class="wrm-separator wrm-modern"
       style="margin: 15px -15px 0px" />
-    <div style="padding-top: 1em; text-align: center">
+    <!-- expander: the QR code is hidden until the user asks for it -->
+    <div
+      class="cross-device-toggle"
+      role="button"
+      tabindex="0"
+      :aria-expanded="expanded"
+      @click="toggle()"
+      @keydown.enter.prevent="toggle()"
+      @keydown.space.prevent="toggle()">
+      <span>Don't see your wallet? Is your wallet on another device?</span>
+      <i
+        class="fas"
+        :class="expanded ? 'fa-chevron-up' : 'fa-chevron-down'" />
+    </div>
+    <div
+      v-if="expanded"
+      style="text-align: center">
       <div class="wrm-dark-gray">
-        Use a wallet on another device:
+        Scan this code with the other device:
       </div>
       <img
         v-if="qrDataUrl"
@@ -57,6 +73,9 @@ export default {
   },
   emits: ['close'],
   setup(props, {emit}) {
+    const expanded = ref(false);
+    const toggle = () => expanded.value = !expanded.value;
+
     const qrDataUrl = ref('');
     watchEffect(async () => {
       try {
@@ -72,7 +91,7 @@ export default {
       }
     });
     const close = () => emit('close');
-    return {close, qrDataUrl};
+    return {close, expanded, qrDataUrl, toggle};
   }
 };
 </script>

--- a/web/components/HintChooser.vue
+++ b/web/components/HintChooser.vue
@@ -21,8 +21,11 @@
     </template>
     <template #hint-list-footer>
       <slot name="hint-list-footer" />
+      <!-- with no wallets to choose from, the QR code is the primary
+        option: show it immediately instead of behind the expander -->
       <CrossDeviceOptions
         v-if="interactionUrl"
+        :collapsible="hints.length > 0"
         :interaction-url="interactionUrl"
         :loading="loading"
         @close="cancel()" />

--- a/web/components/HintChooser.vue
+++ b/web/components/HintChooser.vue
@@ -1,5 +1,6 @@
 <template>
   <WrmHintChooser
+    class="hint-chooser"
     style="user-select: none"
     :hints="hints"
     :cancel-remove-hint-timeout="5000"


### PR DESCRIPTION
The 1p dialog previously scrolled as a whole window, which scrolled the header (and its Close button) out of view, stacked a window scrollbar on top of the wallet hint list's own, and let the page background show through as black bands in dark mode. It also left the cross-device QR section below the fold where users might never discover it.

This PR lays the dialog out as a fixed frame around a single scrollable region, and puts the QR code behind an expander:

- **Header, greeting, and cross-device section never scroll** — they are always on screen.
- **The QR code is behind an expander.** An always-visible prompt ("Don't see your wallet?") keeps the cross-device option discoverable; expanding reveals the QR code and Close button. The toggle is keyboard-accessible (enter/space) with `aria-expanded`. When no wallets are registered (or the user hides the last one), the QR code is the primary option and shows immediately with no toggle — which also keeps the no-wallets message ("You can scan the QR code below") accurate.
- **Only the wallet hint list scrolls.** It flexes to absorb the available height (no more fixed 200px cap in the 1p dialog) — with the QR collapsed the list grows (five wallets fit without scrolling at the default popup size), and it shrinks back to a scrollable region (minimum one row) when the code is expanded. The body region scrolls only as a fallback for windows too short to fit the fixed parts.
- **The content panel exactly fills the popup** (`box-sizing: border-box`, `width/height: 100%`, replacing upstream's content-box `calc(100% - padding)` sizing), so the page background cannot bleed through.
- **The hint list's custom scrollbar styling is fixed**: `scrollbar-width: 6px` is an invalid value (the property accepts only `auto`/`thin`/`none`), and Chromium 121+ ignores all `::-webkit-scrollbar*` rules when the standard `scrollbar-width`/`scrollbar-color` properties are also set. The standard properties are now applied only where `::-webkit-scrollbar` is unsupported (Firefox), so the list reliably shows a persistent scrollbar as the affordance that more wallets are available.

Requirements covered: the user always sees the cross-device prompt; no full-window scrollbar; a visible scrollbar affordance on the wallet list; the header never scrolls; no double scrollbars.

Verified end-to-end against a local mediator with five registered wallets at the real 500×640 popup size, in light and dark mode, in both expander states: header/greeting/prompt pinned in all states, all five wallets visible with the QR collapsed, list scrolls with its own persistent scrollbar when expanded, QR and Close fully visible when expanded, and no background bleed. The persistent custom scrollbar was additionally verified in a headed browser (headless screenshots render overlay scrollbars regardless of styling).

CI runs lint only; lint passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
