### PR TITLE
fix(dev): bind to all interfaces for Docker

### DIFF
--- a/configs/dev.js
+++ b/configs/dev.js
@@ -16,3 +16,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // common paths
 config.paths.cache = path.join(__dirname, '..', '.cache');
 config.paths.log = path.join(os.tmpdir(), 'authn.localhost');
+
+// bind to all interfaces so Docker containers can reach the host via
+// host.docker.internal (which maps to 192.168.65.254, not loopback).
+// note: this also exposes the mediator on all LAN interfaces, not just
+// Docker's bridge — acceptable for local dev, avoid on shared networks.
+config.server.bindAddr = ['0.0.0.0'];


### PR DESCRIPTION
## Summary

- `configs/dev.js` default `bindAddr` is `['authn.localhost']` which resolves to `127.0.0.1` (loopback only)
- On macOS, Docker containers reach the host via `host.docker.internal` → `192.168.65.254`, not loopback
- This causes `cloudflared`'s `mediator-tunnel` container in `chapi-demo-stack` to get connection refused
- Adding `bindAddr = ['0.0.0.0']` makes the mediator reachable from Docker

**Note:** `0.0.0.0` also exposes the mediator on all LAN interfaces — acceptable for local dev, but worth being aware of on shared/corporate networks.

## Test plan

- [ ] Run `node authn.localhost.js` and confirm `HTTPS listening on authn.localhost:33443`
- [ ] Run `docker compose up -d` in `chapi-demo-stack` and confirm mediator-tunnel connects without Error 1033
- [ ] Full wallet → issue → present flow on a phone via Cloudflare tunnel URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)